### PR TITLE
dropdown_render_nav complete

### DIFF
--- a/src/components/Header/Navbar/Dropdown/Dropdown.jsx
+++ b/src/components/Header/Navbar/Dropdown/Dropdown.jsx
@@ -5,7 +5,7 @@ import { motion } from "framer-motion";
 import classes from "./Dropdown.module.scss";
 import ListRoute from "../../../UI/ListRoute/ListRoute";
 
-const Dropdown = ({ dropdownList }) => (
+const Dropdown = ({ mainRoute, dropdownList, dropdownOff }) => (
   <motion.div
     className={classNames(classes.dropdown)}
     initial={{ opacity: 0 }}
@@ -15,16 +15,19 @@ const Dropdown = ({ dropdownList }) => (
     <div className={classes.container}>
       <h3 className={classes.title}>Categories</h3>
       <ul className={classes.list}>
-        {dropdownList.map((item) => (
+        {dropdownList.map((route) => (
           <ListRoute
-            route={`${item}`}
-            content={item}
+            key={route}
+            route={`/shop/${mainRoute}/${route.toLowerCase()}`}
+            content={route}
+            onClick={dropdownOff}
             listClass={classes.listItem}
           />
         ))}
         <ListRoute
-          route="/"
+          route={`/shop/${mainRoute}/&all`}
           content="View all"
+          onClick={dropdownOff}
           listClass={classNames(classes.listItem, classes.viewAll)}
         />
       </ul>
@@ -33,11 +36,15 @@ const Dropdown = ({ dropdownList }) => (
 );
 
 Dropdown.defaultProps = {
-  dropdownList: "",
+  dropdownList: [],
+  mainRoute: "",
+  dropdownOff: (f) => f,
 };
 
 Dropdown.propTypes = {
-  dropdownList: PropTypes.string,
+  dropdownList: PropTypes.instanceOf(Array),
+  mainRoute: PropTypes.string,
+  dropdownOff: PropTypes.func,
 };
 
 export default Dropdown;

--- a/src/components/Header/Navbar/Navbar.jsx
+++ b/src/components/Header/Navbar/Navbar.jsx
@@ -49,6 +49,7 @@ const Nav = (props) => {
           activeClass={activeCls.join(" ")}
           listClass={classes.NavItem}
           dropdownToggle={toggleDropdown}
+          dropdownOff={setMan}
           active={activeDropdown}
           dropdownItems={dropdownItems[Object.keys(activeNav)[0]]}
         />

--- a/src/components/UI/ListRoute/ListRoute.jsx
+++ b/src/components/UI/ListRoute/ListRoute.jsx
@@ -3,9 +3,21 @@ import PropTypes from "prop-types";
 import classNames from "classnames";
 import { NavLink } from "react-router-dom";
 
-const ListRoute = ({ content, route, activeClass, listClass, linkClass }) => (
+const ListRoute = ({
+  content,
+  route,
+  activeClass,
+  listClass,
+  linkClass,
+  onClick = null,
+}) => (
   <li className={classNames(listClass)}>
-    <NavLink to={route} activeClassName={activeClass} className={linkClass}>
+    <NavLink
+      to={route}
+      activeClassName={activeClass}
+      className={linkClass}
+      onClick={() => onClick(false)}
+    >
       {content}
     </NavLink>
   </li>
@@ -15,6 +27,7 @@ ListRoute.defaultProps = {
   activeClass: "",
   listClass: "",
   linkClass: "",
+  onClick: (f) => f,
 };
 
 ListRoute.propTypes = {
@@ -23,6 +36,7 @@ ListRoute.propTypes = {
   activeClass: PropTypes.string,
   listClass: PropTypes.string,
   linkClass: PropTypes.string,
+  onClick: PropTypes.func,
 };
 
 export default ListRoute;

--- a/src/components/UI/NavigationListRoutes/NavigationListRoutes.jsx
+++ b/src/components/UI/NavigationListRoutes/NavigationListRoutes.jsx
@@ -14,11 +14,18 @@ const NavigationListRoutes = ({
   listClass,
   linkClass,
   dropdownToggle,
+  dropdownOff,
   dropdownItems,
 }) => (
   <li className={classNames(listClass)}>
     <AnimatePresence>
-      {active && <Dropdown dropdownList={dropdownItems} />}
+      {active && (
+        <Dropdown
+          mainRoute={content.toLowerCase()}
+          dropdownList={dropdownItems}
+          dropdownOff={dropdownOff}
+        />
+      )}
     </AnimatePresence>
     <NavLink
       to={route}
@@ -38,6 +45,7 @@ NavigationListRoutes.defaultProps = {
   active: false,
   dropdownItems: {},
   dropdownToggle: (f) => f,
+  dropdownOff: (f) => f,
 };
 
 NavigationListRoutes.propTypes = {
@@ -49,6 +57,7 @@ NavigationListRoutes.propTypes = {
   active: PropTypes.bool,
   id: PropTypes.number,
   dropdownToggle: PropTypes.func,
+  dropdownOff: PropTypes.func,
   dropdownItems: PropTypes.instanceOf(Object),
 };
 


### PR DESCRIPTION
1. Dropdown dynamic render data depends on which route we clicked - we will be forwarded to the specific path.
2. Navigation dynamic categories render - depends on which category we click, we will see the specific number of items.
3. We have 1 bug, need to prevent redirecting to the Home path when we already are on the shop path, for example: 

When I click on Shoes and Dropdown opens, then I select Sneakers - I am forwarded to the Shop page with the required route.
(!!!) BUT! If I click on Category in Navbar again - I will be forwarded to the Main Page, which need to fix.